### PR TITLE
clean up Legion (and one compiler) warnings

### DIFF
--- a/legion/legion-hpcg/explicit-spmd/LegionItems.hpp
+++ b/legion/legion-hpcg/explicit-spmd/LegionItems.hpp
@@ -396,8 +396,6 @@ public:
         //
         InlineLauncher inl(req);
         physicalRegion = lrt->map_region(ctx, inl);
-        physicalRegion.wait_until_valid();
-        //
         return physicalRegion;
     }
 
@@ -446,7 +444,9 @@ public:
         logicalRegion = physicalRegion.get_logical_region();
         //
         using GRA = RegionAccessor<AccessorType::Generic, TYPE>;
-        GRA tAcc = physicalRegion.get_field_accessor(0).template typeify<TYPE>();
+        GRA tAcc = physicalRegion.get_field_accessor(0,
+						     true /*silence_warnings*/
+						     ).template typeify<TYPE>();
         //
         Domain tDom = runtime->get_index_space_domain(
             ctx, physicalRegion.get_logical_region().get_index_space()

--- a/legion/legion-hpcg/explicit-spmd/main.cc
+++ b/legion/legion-hpcg/explicit-spmd/main.cc
@@ -313,7 +313,7 @@ mainTask(
         }
         //
         FutureMap fm = runtime->execute_must_epoch(ctx, mel);
-        fm.wait_all_results();
+        fm.wait_all_results(true /*silence_warnings*/);
         //
     }
     // Now that we have all the setup information stored in LogicalRegions,
@@ -363,7 +363,7 @@ mainTask(
         }
         //
         FutureMap fm = runtime->execute_must_epoch(ctx, mel);
-        fm.wait_all_results();
+        fm.wait_all_results(true /*silence_warnings*/);
         //
         const double totalTime = mytimer() - start;
         //
@@ -468,11 +468,7 @@ startBenchmarkTask(
     Array<floatType> b     (regions[rid++], ctx, lrt);
     Array<floatType> x     (regions[rid++], ctx, lrt);
     Array<floatType> xexact(regions[rid++], ctx, lrt);
-    // Now unmap structures that are done using accessors.
-#ifdef LGNCG_TASKING
-    lrt->unmap_all_regions(ctx);
-#endif
-    // Past this point, we have to manually unmap any mapped regions.
+
     ////////////////////////////////////////////////////////////////////////////
     // Private data for this task.
     ////////////////////////////////////////////////////////////////////////////
@@ -543,6 +539,12 @@ startBenchmarkTask(
              << setup_time << endl;
     }
 
+    // Now unmap structures that are done using accessors.
+#ifdef LGNCG_TASKING
+    lrt->unmap_all_regions(ctx);
+#endif
+    // Past this point, we have to manually unmap any mapped regions.
+
     ////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////
     // Start of benchmark.
@@ -557,7 +559,7 @@ startBenchmarkTask(
     //QuickPath means we do on one call of each block of repetitive code.
     if (quickPath) numberOfCalls = 1;
     //
-    const auto *const Asclrs = A.sclrs->data();
+    //const auto *const Asclrs = A.sclrs->data();
 
     ////////////////////////////////////////////////////////////////////////////
     // Problem Sanity Phase


### PR DESCRIPTION
These changes eliminate the various warnings that `-lg:warn` has been spewing, along with one "unused variable" compiler warning.  Make sure you update the Legion runtime as well, since at least one warning was incorrect and has been fixed there.