### PR TITLE
Warning cleanup (attempt #2)

### DIFF
--- a/legion/legion-hpcg/explicit-spmd/.gitignore
+++ b/legion/legion-hpcg/explicit-spmd/.gitignore
@@ -1,0 +1,5 @@
+*.o
+*.a
+*~
+legion-xhpcg
+

--- a/legion/legion-hpcg/explicit-spmd/ExchangeHalo.hpp
+++ b/legion/legion-hpcg/explicit-spmd/ExchangeHalo.hpp
@@ -50,7 +50,7 @@
 
 #include <cstdlib>
 
-#if 0
+#ifdef LGNCG_TASKING
 #define LGNCG_DO_TASKY_EXCHANGE
 #endif
 
@@ -115,7 +115,7 @@ ExchangeHalo(
     }
     // x (private partition).
     RegionRequirement xrr(
-        xPrivateLR, RO_E, xPrivateLR
+        xPrivateLR, RO_E, x.logicalRegion
     );
     tl.add_region_requirement(xrr).add_field(x.fid);
     // Matrix pieces.
@@ -217,6 +217,7 @@ ExchangeHaloTask(
     }
     myPBs.ready.arrive(1);
     myPBs.ready = lrt->advance_phase_barrier(ctx, myPBs.ready);
+    lrt->unmap_all_regions(ctx);
     //
     for (int n = 0; n < nTxNeighbors; ++n) {
         static const int fid = 0;

--- a/legion/legion-hpcg/explicit-spmd/main.cc
+++ b/legion/legion-hpcg/explicit-spmd/main.cc
@@ -469,12 +469,6 @@ startBenchmarkTask(
     Array<floatType> x     (regions[rid++], ctx, lrt);
     Array<floatType> xexact(regions[rid++], ctx, lrt);
 
-    // Now unmap structures that are done using accessors.
-#ifdef LGNCG_TASKING
-    lrt->unmap_all_regions(ctx);
-#endif
-    // Past this point, we have to manually unmap any mapped regions.
-
     ////////////////////////////////////////////////////////////////////////////
     // Private data for this task.
     ////////////////////////////////////////////////////////////////////////////
@@ -545,6 +539,11 @@ startBenchmarkTask(
              << setup_time << endl;
     }
 
+    // Now unmap structures that are done using accessors.
+#ifdef LGNCG_TASKING
+    lrt->unmap_all_regions(ctx);
+#endif
+    // Past this point, we have to manually unmap any mapped regions.
 
     ////////////////////////////////////////////////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
By moving the halo exchange into a subtask (an option that was already there, but not
enabled), it seems possible to move the `unmap_all_regions` call in startBenchmarkTask back
down to where it needs to be to make the Legion runtime happy.

Please double-check the correctness before merging.  :)